### PR TITLE
Docker: run bundler before importing our code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN adduser --disabled-login --gecos "Klausurtool ruby-on-rails" klausurtool
 
 WORKDIR /home/klausurtool/klausurtool-ror/
 
-# copy project files
-COPY . .
-
+# copy gemfiles and run bundler
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
 RUN bundle install
+
+# copy everything else (do this after installing deps, our code changes more often than deps)
+COPY . .
 
 # TODO: ony chown what really needs to be writable
 RUN chown -hR klausurtool .


### PR DESCRIPTION
Docker creates a intermediate image for every step in the Dockerfile.
Those images are reused whenever the context of the command did not
change (the copied files in this case). If we install our dependencies
first, and then import the rest of our project, Docker will be able to
reuse the intermediate image containing our already installed
dependencies.