### PR TITLE
Removed reporting of translation errors

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # Raises error for missing translations
-  config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = false
 
   # Different prefix for assets in development mode to use pre-compiled
   # assets in production mode


### PR DESCRIPTION
 * It "overrode" other errors
 * E.g. "500" (translation missing) was displayed instead of "404"