### PR TITLE
Reduce complexity of ausleihe_controller#switch

### DIFF
--- a/app/controllers/ausleihe_controller.rb
+++ b/app/controllers/ausleihe_controller.rb
@@ -209,19 +209,6 @@ class AusleiheController < ApplicationController
     archived.save!
   end
 
-  def has_mixed_content?(old_folder_instances)
-    lend_outs = old_folder_instances.map { |i| i.old_lend_out }
-    lent = lend_outs.reject { |l| l.nil? }
-
-    if lent.empty?
-      mixed_content = false
-    else
-      mixed_content = (lent.count != lend_outs.count)
-    end
-
-    mixed_content
-  end
-
   def build_invalid_input_for_switch_message(folder_list, lent)
     lent_as_strings = lent
                           .map { |f, barcode, _| "#{barcode} (#{f})" }

--- a/app/controllers/ausleihe_controller.rb
+++ b/app/controllers/ausleihe_controller.rb
@@ -59,7 +59,7 @@ class AusleiheController < ApplicationController
     lent_is_not_empty = (not lent.empty?)
 
     if lent_is_not_empty && not_all_folders_are_lent
-      flash[:alert] = build_invalid_input_for_switch_message(folder_list, lent)
+      flash[:alert] = invalid_input_for_switch_message(folder_list, lent)
       redirect_to ausleihe_path and return
     end
 
@@ -209,7 +209,7 @@ class AusleiheController < ApplicationController
     archived.save!
   end
 
-  def build_invalid_input_for_switch_message(folder_list, lent)
+  def invalid_input_for_switch_message(folder_list, lent)
     lent_as_strings = lent
                           .map { |f, barcode, _| "#{barcode} (#{f})" }
                           .join(', ')

--- a/app/controllers/ausleihe_controller.rb
+++ b/app/controllers/ausleihe_controller.rb
@@ -188,7 +188,6 @@ class AusleiheController < ApplicationController
 
   end
 
-
   private
   def old_lend_out_params
     params.require(:old_lend_out).permit(:imt, :lender, :deposit, :weigth, :receiver, :recivingTime, :old_folder_instances => [])
@@ -217,9 +216,7 @@ class AusleiheController < ApplicationController
                          .map { |f, barcode, _| "#{barcode} (#{f})" }
                          .join(', ')
 
-    message = ["#{Time.new}: Eingabe enthält gemischte Ordner. Entweder Ausleihen oder Zurücknehmen."]
-    message << "Ordner-Exemplare: #{all_as_strings}, davon verliehen: #{lent_as_strings}"
-    join = message.join
+    "#{Time.new}: Eingabe enthält gemischte Ordner. Entweder Ausleihen oder Zurücknehmen. Ordner-Exemplare: #{all_as_strings}, davon verliehen: #{lent_as_strings}"
   end
 
 end


### PR DESCRIPTION
 * ausleihe_controller#switch is very complex
 * This could lead to hard-to-fix bugs
 * Method-flow should be simplified to reduce the complexity of this method
