### PR TITLE
Archiving exams

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -71,3 +71,7 @@ nav {
 .red {
   color: $red;
 }
+
+.check_box_in_form input{
+  width: 34px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# Provides an index page for the application
 class ApplicationController < ActionController::Base
   include PaginatedExamsList
 

--- a/app/controllers/ausleihe_controller.rb
+++ b/app/controllers/ausleihe_controller.rb
@@ -1,3 +1,4 @@
+# Controller to actions related to lending and receiving folders
 class AusleiheController < ApplicationController
   include LentFolders, LendingArchive, PaginatedFolderInstanceList, PaginatedExamsList, AusleiheHelper
 

--- a/app/controllers/concerns/lending_archive.rb
+++ b/app/controllers/concerns/lending_archive.rb
@@ -1,3 +1,5 @@
+
+# Provides the lent and history actions
 module LendingArchive
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/lent_folders.rb
+++ b/app/controllers/concerns/lent_folders.rb
@@ -1,3 +1,4 @@
+# Provides lent and history action for lendouts
 module LentFolders
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/paginated_exams_list.rb
+++ b/app/controllers/concerns/paginated_exams_list.rb
@@ -1,3 +1,4 @@
+# Provides a paginated exams list
 module PaginatedExamsList
   extend ActiveSupport::Concern
   include Searchable

--- a/app/controllers/concerns/paginated_folder_instance_list.rb
+++ b/app/controllers/concerns/paginated_folder_instance_list.rb
@@ -1,3 +1,4 @@
+# Provides a paginated list of folder instances
 module PaginatedFolderInstanceList
   extend ActiveSupport::Concern
   include Searchable

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -1,3 +1,4 @@
+# Provides a method to clear params[:search] when params[:reset] is received
 module Searchable
   extend ActiveSupport::Concern
 

--- a/app/controllers/internal/admin/lendouts_controller.rb
+++ b/app/controllers/internal/admin/lendouts_controller.rb
@@ -1,3 +1,4 @@
+# Provides an index page for the adminstration interface
 module Internal
   module Admin
     class LendoutsController < ApplicationController

--- a/app/controllers/internal/admin/print_controller.rb
+++ b/app/controllers/internal/admin/print_controller.rb
@@ -2,6 +2,7 @@ require 'barby'
 require 'barby/barcode/ean_8'
 require 'barby/outputter/html_outputter'
 
+# Provides actions related to printing
 module Internal
   module Admin
     # Controller to provide print actions.

--- a/app/controllers/old_exams_controller.rb
+++ b/app/controllers/old_exams_controller.rb
@@ -1,3 +1,4 @@
+# Provides CRUD actions for exams
 class OldExamsController < ApplicationController
   include PaginatedExamsList
 

--- a/app/controllers/old_exams_controller.rb
+++ b/app/controllers/old_exams_controller.rb
@@ -78,7 +78,7 @@ class OldExamsController < ApplicationController
 
   private
   def old_exam_params
-    params.require(:old_exam).permit(:title, :examiners, :date, :old_folder_id)
+    params.require(:old_exam).permit(:title, :examiners, :date, :old_folder_id, :unarchived)
   end
 
 end

--- a/app/controllers/old_folder_instances_controller.rb
+++ b/app/controllers/old_folder_instances_controller.rb
@@ -1,3 +1,4 @@
+# Provides CRUD actions for folder instances
 class OldFolderInstancesController < ApplicationController
   include PaginatedFolderInstanceList
 

--- a/app/controllers/old_folders_controller.rb
+++ b/app/controllers/old_folders_controller.rb
@@ -81,14 +81,16 @@ class OldFoldersController < ApplicationController
       @old_folder = OldFolder.new
     end
 
-    number_of_filler_exams = 37 - @old_folder.old_exams.count
+    @unarchived_exams = @old_folder.old_exams.select { |e| e.unarchived? }
+
+    number_of_filler_exams = 37 - @unarchived_exams.count
     if number_of_filler_exams < 0
       flash[:warning] = 'Es können nicht alle Prüfungen auf eine Seite gedruckt werden. Bitte einige Klausuren archivieren oder auslaugern.'
     end
 
     filler_exam = OldExam.new
     while number_of_filler_exams > 0
-      @old_folder.old_exams << filler_exam
+      @unarchived_exams << filler_exam
       number_of_filler_exams -= 1
     end
 

--- a/app/controllers/old_folders_controller.rb
+++ b/app/controllers/old_folders_controller.rb
@@ -1,3 +1,4 @@
+# Provides CRUD actions for folders
 class OldFoldersController < ApplicationController
   include Searchable
 
@@ -67,7 +68,8 @@ class OldFoldersController < ApplicationController
     redirect_to old_folders_path
   end
 
-
+  # Generates a table of contents from the given params[:old_folder_id]
+  # TODO: Move to Internal::Admin::PrintController
   def toc
     id = params[:old_folder_id]
     if id.nil?

--- a/app/views/old_exams/edit.html.erb
+++ b/app/views/old_exams/edit.html.erb
@@ -41,6 +41,12 @@
           <%= f.date_select :date, :required => true, :class => 'form-control' %>
         </div>
       </div>
+      <div class="form-group row">
+        <%= f.label :unarchived, 'Im Inhaltsverz.?', :class => 'control-label col-sm-2' %>
+        <div class="col-sm-10 check_box_in_form">
+          <%= f.check_box :unarchived, :class => 'form-control' %>
+        </div>
+      </div>
       <div class="pull-right">
         <div class="form-group row">
           <div class="col-sm-2">

--- a/app/views/old_exams/show.html.erb
+++ b/app/views/old_exams/show.html.erb
@@ -15,7 +15,7 @@
     <dt>Datum</dt>
     <dd><%= @old_exam.date %></dd>
     <dt>Im Inhaltsverz.?</dt>
-    <dd><%= @old_exam.unarchived? ? '✔' : ' ' %></dd>
+    <dd><%= @old_exam.unarchived? ? '✔' : '✗' %></dd>
   </dl>
   <div class="clearfix"></div>
 </div>

--- a/app/views/old_exams/show.html.erb
+++ b/app/views/old_exams/show.html.erb
@@ -14,6 +14,8 @@
     <dd><%= @old_exam.examiners %></dd>
     <dt>Datum</dt>
     <dd><%= @old_exam.date %></dd>
+    <dt>Im Inhaltsverz.?</dt>
+    <dd><%= @old_exam.unarchived? ? '✔' : ' ' %></dd>
   </dl>
   <div class="clearfix"></div>
 </div>

--- a/app/views/old_folders/_exams_in_folder.html.erb
+++ b/app/views/old_folders/_exams_in_folder.html.erb
@@ -10,6 +10,7 @@
       <th>Veranstaltungen</th>
       <th>Prüfer</th>
       <th>Datum</th>
+      <th title="Ob diese Prüfung im Inhaltsverzeichnis angezeigt wird.">TOC<sup>?</sup></th>
       <th></th>
     </tr>
 
@@ -19,6 +20,7 @@
           <td><%= link_to e.title, e %></td>
           <td><%= e.examiners %></td>
           <td><%= e.date %></td>
+          <td><%= e.unarchived? ? '✔' : ' ' %></td>
           <td>
             <%= link_to 'Bearbeiten', edit_old_folder_old_exam_path(@old_folder, e) %>,
             <%= link_to 'Löschen', [e.old_folder, e], method: :delete,

--- a/app/views/old_folders/toc.html.erb
+++ b/app/views/old_folders/toc.html.erb
@@ -14,7 +14,7 @@
         <th>Dozent</th>
         <th>Datum</th>
       </tr>
-      <% @old_folder.old_exams.each do |e| %>
+      <% @unarchived_exams.each do |e| %>
           <tr>
             <td class="toc-table-title"><% if e.title.nil? %>&nbsp;<% else %><%= e.title %><% end %></td>
             <td class="toc-table-examiners"><%= e.examiners %></td>

--- a/db/migrate/20160425120127_add_unarchived_to_old_exams.rb
+++ b/db/migrate/20160425120127_add_unarchived_to_old_exams.rb
@@ -1,0 +1,5 @@
+class AddUnarchivedToOldExams < ActiveRecord::Migration
+  def change
+  	    add_column :old_exams, :unarchived, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160313124532) do
+ActiveRecord::Schema.define(version: 20160425120127) do
 
   create_table "archived_old_lend_outs", force: :cascade do |t|
     t.string   "deposit",              limit: 255
@@ -52,8 +52,10 @@ ActiveRecord::Schema.define(version: 20160313124532) do
     t.string   "examiners",     limit: 255
     t.date     "date"
     t.integer  "old_folder_id", limit: 4
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.boolean  "visible"
+    t.boolean  "unarchived",                default: true
   end
 
   add_index "old_exams", ["old_folder_id"], name: "index_old_exams_on_old_folder_id", using: :btree

--- a/spec/factories/old_exam.rb
+++ b/spec/factories/old_exam.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     o.date { Faker::Date.birthday }
     o.title { Faker::Name.name }
     o.examiners { Faker::Name.name }
+    o.unarchived true
   end
 end

--- a/spec/models/old_exam_spec.rb
+++ b/spec/models/old_exam_spec.rb
@@ -1,19 +1,37 @@
 require 'rails_helper'
 
-EXAMINERS_FOO_BAR = "Foo Bar"
-EXAMINERS_FOO = "Foo"
-EXAMINERS_BAR = "Bar"
+EXAMINERS_FOO_BAR = 'Foo Bar'
+EXAMINERS_FOO = 'Foo'
+EXAMINERS_BAR = 'Bar'
 
-DATE_2015_12_21 = "2015-12-21 00:00:00"
-DATE_2015_12_22 = "2015-12-22 00:00:00"
+DATE_2015_12_21 = '2015-12-21 00:00:00'
+DATE_2015_12_22 = '2015-12-22 00:00:00'
 
-TITLE_EXAM_TITLE = "Exam Title"
-TITLE_PRUEFUNG = "Prüfung"
-TITLE_TIT_LE = "Tit le"
+TITLE_EXAM_TITLE = 'Exam Title'
+TITLE_PRUEFUNG = 'Prüfung'
+TITLE_TIT_LE = 'Tit le'
 
 
 describe OldExam do
-  describe "Basic functionality" do
+  describe 'Validations' do
+    it 'has a valid factory' do
+      expect(FactoryGirl.build(:old_exam)).to be_valid
+    end
+
+    it 'cannot have empty date' do
+      expect(FactoryGirl.build(:old_exam, date: nil)).to_not be_valid
+    end
+
+    it 'cannot have empty title' do
+      expect(FactoryGirl.build(:old_exam, title: nil)).to_not be_valid
+    end
+
+    it 'cannot have empty examiners' do
+      expect(FactoryGirl.build(:old_exam, examiners: nil)).to_not be_valid
+    end
+  end
+  
+  describe 'Search functions' do
 
     before(:each) do
       old_folder = FactoryGirl.build(:old_folder)
@@ -32,57 +50,41 @@ describe OldExam do
       @exam3.destroy!
     end
 
-    it "has a valid factory" do
-      expect(FactoryGirl.build(:old_exam)).to be_valid
-    end
-
-    it "cannot have empty date" do
-      expect(FactoryGirl.build(:old_exam, date: nil)).to_not be_valid
-    end
-
-    it "cannot have empty title" do
-      expect(FactoryGirl.build(:old_exam, title: nil)).to_not be_valid
-    end
-
-    it "cannot have empty examiners" do
-      expect(FactoryGirl.build(:old_exam, examiners: nil)).to_not be_valid
-    end
-
-    it "returns everything for empty search" do
+    it 'returns everything for empty search' do
       expect(OldExam.search('')).to match_array([@exam1, @exam2, @exam3])
     end
 
-    it "returns empty array for non-matching search" do
-      expect(OldExam.search("2012-12-20")).to match_array([])
+    it 'returns empty array for non-matching search' do
+      expect(OldExam.search('2012-12-20')).to match_array([])
     end
 
-    it "finds 1 element for date search matching 1 element" do
-      expect(OldExam.search("2015-12-21")).to match_array([@exam1])
-      expect(OldExam.search("2015-12-22")).to match_array([@exam2, @exam3])
+    it 'finds 1 element for date search matching 1 element' do
+      expect(OldExam.search('2015-12-21')).to match_array([@exam1])
+      expect(OldExam.search('2015-12-22')).to match_array([@exam2, @exam3])
     end
 
-    it "finds 2 elements for date search matching 2 elements" do
-      expect(OldExam.search("2015-12-22")).to match_array([@exam2, @exam3])
+    it 'finds 2 elements for date search matching 2 elements' do
+      expect(OldExam.search('2015-12-22')).to match_array([@exam2, @exam3])
     end
 
-    it "finds 3 elements for partly date search matching 3 elements" do
-      expect(OldExam.search("2015-12")).to match_array([@exam1, @exam2, @exam3])
+    it 'finds 3 elements for partly date search matching 3 elements' do
+      expect(OldExam.search('2015-12')).to match_array([@exam1, @exam2, @exam3])
     end
 
-    it "finds 1 match for title search matching 1 element" do
+    it 'finds 1 match for title search matching 1 element' do
       expect(OldExam.search(TITLE_PRUEFUNG)).to match_array([@exam3])
     end
 
-    it "finds 2 matches for title search matching 2 elements" do
+    it 'finds 2 matches for title search matching 2 elements' do
       expect(OldExam.search(TITLE_TIT_LE)).to match_array([@exam1, @exam2])
     end
 
 
-    it "finds 1 match for examiners search matching 1 element" do
+    it 'finds 1 match for examiners search matching 1 element' do
       expect(OldExam.search(EXAMINERS_FOO_BAR)).to match_array([@exam1])
     end
 
-    it "finds 2 matches for examiners search matching 2 elements" do
+    it 'finds 2 matches for examiners search matching 2 elements' do
       expect(OldExam.search(EXAMINERS_FOO)).to match_array([@exam1, @exam2])
       expect(OldExam.search(EXAMINERS_BAR)).to match_array([@exam1, @exam3])
     end

--- a/spec/views/old_folders/toc.html.erb_spec.rb
+++ b/spec/views/old_folders/toc.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "old_folders/toc.html.erb" do
   it "displays the " do
     old_folder = FactoryGirl.build(:old_folder, title: "My Name")
     assign(:old_folder, old_folder)
-
+    assign(:unarchived_exams, [])
     render
 
     expect(rendered).to include('Ordner: My Name')


### PR DESCRIPTION
 * Fixes #163
 * Adds ```unarchived``` to ```old_exam```
 * Extends UI to handle archving and unarchiving
 * Table of contents now only shows ```unarchived``` exams

**Exam table in "view folder":**
![folder](https://cloud.githubusercontent.com/assets/1698836/14785729/81722bf6-0afc-11e6-9afc-7042a263d0ad.png)

**Viewing and editing exam details:**
![show_exam](https://cloud.githubusercontent.com/assets/1698836/14785728/816798bc-0afc-11e6-8515-59b85776ea14.png)
![edit_exam](https://cloud.githubusercontent.com/assets/1698836/14785727/81652ba4-0afc-11e6-9efd-d31fa66d953c.png)


**Future work:** Make exams independent of folder and relate them to a lecture.